### PR TITLE
Revert "Adding public image link to ImageUri"

### DIFF
--- a/aimodelshare/base_image.py
+++ b/aimodelshare/base_image.py
@@ -131,7 +131,7 @@ def lambda_using_base_image(account_id, region, session, project_name, model_dir
         FunctionName=project_name,
         Role='arn:aws:iam::' + account_id + ':role/' + role_name,
         Code={
-            'ImageUri': 'public.ecr.aws/y2e2a1d6/aimodelshare-base-image-public:latest'
+            'ImageUri': account_id + '.dkr.ecr.' + region + '.amazonaws.com/aimodelshare-base-image:latest'
         },
         PackageType="Image",
         Timeout=int(timeout),


### PR DESCRIPTION
Reverts AIModelShare/aimodelshare#65

@mvedang getting following error due to untested code.  Please test and request new pull request.

InvalidParameterValueException: An error occurred (InvalidParameterValueException) when calling the CreateFunction operation: Source image public.ecr.aws/y2e2a1d6/aimodelshare-base-image-public:latest is not valid. Provide a valid source image.