### PR TITLE
fix share_dataset bug

### DIFF
--- a/aimodelshare/data_sharing/data_sharing_templates/buildspec.txt
+++ b/aimodelshare/data_sharing/data_sharing_templates/buildspec.txt
@@ -5,7 +5,7 @@ phases:
     commands:
       - aws configure set aws_access_key_id $aws_access_key_id
       - aws configure set aws_secret_access_key $aws_secret_access_key
-      - aws ecr-public get-login-password --region $region | docker login --username AWS --password-stdin public.ecr.aws
+      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
   build:
     commands:
       - docker build -t $repository:$dataset_tag .


### PR DESCRIPTION
Context: Everything looks fine with the share_dataset function on the python side (by itself and through create_competition) but then the image with the dataset is not publishing to the ECR.

The logs showed an error that we "could not connect to the endpoint URL". 

I discovered [in the documentation ](https://docs.aws.amazon.com/AmazonECR/latest/public/getting-started-cli.html) that "The Amazon ECR Public registry requires authentication in the us-east-1 Region". 

Hard coding the region in this line fixes the issue with the share_dataset function, but I'm not sure if it might cause complications elsewhere? @mikedparrott 