### PR TITLE
Add missing packages to Conda-Forge meta.yaml

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -23,14 +23,19 @@ requirements:
     - boto3 ==1.18.2
     - botocore ==1.21.2
     - docker-py ==5.0.0
+    - ipython
+    - jinja2
     - keras2onnx >=1.7.0
+    - networkx == 2.6.3
     - onnx >=1.9.0
     - onnxconverter-common >=1.7.0
     - onnxmltools >=1.6.1
     - onnxruntime >=1.7.0
+    - pydot == 1.3.0
     - pyjwt ==2.2.0
     - pympler ==0.9
     - python >=3.7
+    - regex
     - scikit-learn ==0.24.2
     - seaborn >=0.11.2
     - shortuuid >=1.0.8
@@ -39,7 +44,7 @@ requirements:
     - tf2onnx
     - pytorch >=1.8.1
     - urllib3 ==1.25.11
-    - wget ==1.20.3
+    - python-wget ==3.2
     - xgboost >=0.90
     - dill
 


### PR DESCRIPTION
## Summary 
Upon testing conda-forge installation for version `0.0.101` , there are few
missing packages that can possibly lead to ModuleNotFound Errors. 

Adding packages to meta.yaml, should allow for conda-forge to install 
these additional packages by default.

## Additions 
- Added `Regex` , `pydot` , `networkx==2.6.3` , `ipython` , `jinja2` to `meta.yaml`


## Changes

The `wget` package is called `wget` on Pypi and `python-wget` on anaconda . Hence the change in t


## Todo List 

- [ ] Confirm Jinja2 version required for AIModelshare
- [ ] Confirm Pydot version requirted for AIModelshare