### PR TITLE
Replication Debugging and Corresponding  Bug Fixes

### DIFF
--- a/aimodelshare/aimsonnx.py
+++ b/aimodelshare/aimsonnx.py
@@ -1278,6 +1278,13 @@ def instantiate_model(apiurl, version=None, trained=False, reproduce=False, subm
 
     resp = requests.post(apiurl_eval,headers=headers,data=json.dumps(post_dict)) 
 
+    # Missing Check for response from Lambda. 
+    try :
+        resp.raise_for_status()
+    except requests.exceptions.HTTPError :
+        raise Exception(f"Error: Received {resp.status_code} from AWS, Please check if Model Version is correct.")
+
+
     resp_dict = json.loads(resp.text)
 
     if resp_dict['model_metadata'] == None:

--- a/aimodelshare/aimsonnx.py
+++ b/aimodelshare/aimsonnx.py
@@ -1400,7 +1400,7 @@ def instantiate_model(apiurl, version=None, trained=False, reproduce=False, subm
             # Get leaderboard
             status = wget.download(model_weight_url, out=temp_path)
             onnx_model = onnx.load(temp_path)
-            model_weights = pickle.loads(_get_metadata(onnx_model)['model_weights'])
+            model_weights = np.array([np.array(weight) for weight in ast.literal_eval(_get_metadata(onnx_model)['model_weights'])])
             
             model = tf.keras.Sequential().from_config(model_config)
 

--- a/aimodelshare/main/eval_lambda.txt
+++ b/aimodelshare/main/eval_lambda.txt
@@ -293,7 +293,7 @@ def handler(event, context):
             # the model version is found (users didn't only submit prediction for this version)
             if model_metadata_json:
                 if reproduce:
-                    reproducibility_env_json = get_reproducibility_env(version=version,submission_type)
+                    reproducibility_env_json = get_reproducibility_env(version=version,submission_type = submission_type)
                 elif trained:
                     # Get the presigned url.
                     s3_client=boto3.client("s3")

--- a/aimodelshare/main/eval_lambda.txt
+++ b/aimodelshare/main/eval_lambda.txt
@@ -293,7 +293,7 @@ def handler(event, context):
             # the model version is found (users didn't only submit prediction for this version)
             if model_metadata_json:
                 if reproduce:
-                    reproducibility_env_json = get_reproducibility_env(version=version)
+                    reproducibility_env_json = get_reproducibility_env(version=version,submission_type)
                 elif trained:
                     # Get the presigned url.
                     s3_client=boto3.client("s3")
@@ -1501,7 +1501,7 @@ def get_public_private_split(submission_type="competition"):
     public_private_split_dict = json.load(open("/tmp/public_private_split.json","rb")) 
     return float(public_private_split_dict["public_private_split"])
 
-def get_reproducibility_env(version=None):
+def get_reproducibility_env(version=None,submission_type="competition"):
     s3 = boto3.resource("s3")
     bucket = s3.Bucket("$bucket_name")
 
@@ -1511,7 +1511,7 @@ def get_reproducibility_env(version=None):
                 bucket.download_fileobj("$unique_model_id/runtime_reproducibility.json",  temp_path)
         else:
             with open("/tmp/reproducibility.json", "wb") as temp_path:
-                bucket.download_fileobj("$unique_model_id/competition/reproducibility_v{}.json".format(version),  temp_path)
+                bucket.download_fileobj("$unique_model_id/" + submission_type + "/reproducibility_v{}.json".format(version),  temp_path)
         
         reproducibility_env_json = json.load(open("/tmp/reproducibility.json","rb"))
     except botocore.exceptions.ClientError as e:

--- a/aimodelshare/main/eval_lambda.txt
+++ b/aimodelshare/main/eval_lambda.txt
@@ -1511,7 +1511,7 @@ def get_reproducibility_env(version=None):
                 bucket.download_fileobj("$unique_model_id/runtime_reproducibility.json",  temp_path)
         else:
             with open("/tmp/reproducibility.json", "wb") as temp_path:
-                bucket.download_fileobj("$unique_model_id/reproducibility_v{}.json".format(version),  temp_path)
+                bucket.download_fileobj("$unique_model_id/competition/reproducibility_v{}.json".format(version),  temp_path)
         
         reproducibility_env_json = json.load(open("/tmp/reproducibility.json","rb"))
     except botocore.exceptions.ClientError as e:

--- a/aimodelshare/object_oriented.py
+++ b/aimodelshare/object_oriented.py
@@ -219,6 +219,9 @@ class ModelPlayground:
         
     def instantiate_model(self, version=None, trained=False, reproduce=False, submission_type="competition"): 
         """
+
+        DOES NOT WORK FOR MODELPLAYGROUND , ADD corresponding description.
+
         Import a model previously submitted to a leaderboard to use in your session
 
         Parameters:
@@ -232,6 +235,7 @@ class ModelPlayground:
         --------
         model: model chosen from leaderboard
         """
+        raise AssertionError("You are trying to Instantiate model with ModelPlayground Object, Please use the competition object to Instantiate model")
         from aimodelshare.aimsonnx import instantiate_model
         model = instantiate_model(apiurl=self.playground_url, trained=trained, version=version, reproduce=reproduce, submission_type=submission_type)
         return model

--- a/aimodelshare/object_oriented.py
+++ b/aimodelshare/object_oriented.py
@@ -219,9 +219,6 @@ class ModelPlayground:
         
     def instantiate_model(self, version=None, trained=False, reproduce=False, submission_type="competition"): 
         """
-
-        DOES NOT WORK FOR MODELPLAYGROUND , ADD corresponding description.
-
         Import a model previously submitted to a leaderboard to use in your session
 
         Parameters:


### PR DESCRIPTION
The following PR has the fixes for 

1. Raise HTTPError when lambda responds with an HTTP code of 4XX or 5XX. 
2. Correct the path for reproducibility.json files in S3 buckets  - Add submission_type to Path.
3. Add AssertionError when someone tries to instantiate the model with the competition object. 
4. Fix parsing and loading weights for Keras models from Onnx file stored in S3 Bucket.

